### PR TITLE
Add the ability to specify a Charset when reading property files

### DIFF
--- a/sofia-core/src/main/java/com/antwerkz/sofia/SofiaConfig.java
+++ b/sofia-core/src/main/java/com/antwerkz/sofia/SofiaConfig.java
@@ -5,6 +5,9 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.charset.Charset;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -21,6 +24,8 @@ public class SofiaConfig {
   private Map<String, String> properties;
   private boolean generateJavascript;
   private File javascriptOutputFile;
+  // This is the default charset used when reading property files from an InputStream
+  private Charset charset = Charset.forName("ISO-8859-1");
   private Map<String, Map<String, String>> bundles;
 
   public String getBundleName() {
@@ -126,9 +131,12 @@ public class SofiaConfig {
 
   private Map<String, String> loadProperties(InputStream inputStream) {
     Map<String, String> map = new TreeMap<>();
-    try (InputStream stream = inputStream) {
+    try (
+      InputStream stream = inputStream;
+      Reader reader = new InputStreamReader(stream, charset)
+    ) {
       Properties props = new Properties();
-      props.load(stream);
+      props.load(reader);
       for (Entry<Object, Object> entry : props.entrySet()) {
         map.put((String) entry.getKey(), (String) entry.getValue());
       }
@@ -154,6 +162,14 @@ public class SofiaConfig {
   public SofiaConfig setJavascriptOutputFile(File file) {
     this.javascriptOutputFile = file;
     return this;
+  }
+
+  public Charset getCharset() {
+    return charset;
+  }
+
+  public void setCharset(Charset charset) {
+    this.charset = charset;
   }
 
   public Map<String, Map<String, String>> getBundles() {


### PR DESCRIPTION
Starting with Java 1.6, Properties has a .load() method accepting a Reader as an
argument. By default, the method using an InputStream as an argument will try
and decode the file using ISO-8859-1.

Change the code of .loadProperties() to use a Reader instead, and add the
ability to change the Charset used when reading files.

---

FURTHER NOTES:
- More generally, is the code written for 1.6 or 1.7? If 1.7, a ton of `Objects.requireNonNull()` can be added to setters.
- The regex to detect whether the original file has a locale specification is broken (the dot of ".properties" is not escaped, but that is only one problem).
- Why is `bundles` only initialized in `discoverBundles` and not at init time?
- Others...
