### PR TITLE
README: update option table to account for .setCharset()

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -115,6 +115,7 @@ There are a few configuration options:
 |playController|Generate code for use in play applications|false
 |jsOutputFile|The javascript file to generate|src/main/webapp/js/sofia.js
 |javascript|Enable javascript generation|false
+|charset|Change the character coding used when reading property files|ISO-8859-1
 |=======================
 
 If you'd like continuous monitoring and regeneration of your files, there's also "sofia:watch."  Using this target,


### PR DESCRIPTION
One thing I am not sure of, here, is whether a `Charset` is a good idea... Maybe it would be better if the argument were a `String` and use `Charset.forName()`?
